### PR TITLE
Add option to start the timer paused

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,10 @@ pub(crate) enum Mode {
         #[clap(long = "no-millis", short = 'M', takes_value = false)]
         no_millis: bool,
 
+        /// Start the timer paused
+        #[clap(long = "paused", short = 'P', takes_value = false)]
+        paused: bool,
+
         /// Command to run when the timer ends
         #[clap(long, short, multiple = true, allow_hyphen_values = true)]
         execute: Vec<String>,
@@ -110,6 +114,7 @@ impl App {
             Mode::Timer {
                 duration,
                 no_millis,
+                paused,
                 execute,
             } => {
                 let format = if *no_millis {
@@ -122,6 +127,7 @@ impl App {
                     self.size,
                     style,
                     format,
+                    *paused,
                     execute.to_owned(),
                 ));
             }

--- a/src/app/modes/timer.rs
+++ b/src/app/modes/timer.rs
@@ -24,6 +24,7 @@ impl Timer {
         size: u16,
         style: Style,
         format: DurationFormat,
+        paused: bool,
         execute: Vec<String>,
     ) -> Self {
         Self {
@@ -32,7 +33,7 @@ impl Timer {
             execute,
             style,
             format,
-            ended_at: Some(Local::now() + duration),
+            ended_at: (!paused).then(|| Local::now() + duration),
             execute_result: RefCell::new(None),
         }
     }


### PR DESCRIPTION
For my usage of the timer I've been starting it then hitting space and later letting it run when I've done some other things. This PR adds an option to the timer to start it in the paused state.