### PR TITLE
Fix regressions caused by ratatui migration

### DIFF
--- a/clock-tui/src/app/modes.rs
+++ b/clock-tui/src/app/modes.rs
@@ -7,7 +7,6 @@ mod timer;
 use std::cmp::min;
 use std::fmt::Write as _;
 
-use crate::clock_text::font::bricks::BricksFont;
 use crate::clock_text::ClockText;
 use chrono::Duration;
 pub(crate) use clock::Clock;

--- a/clock-tui/src/bin/main.rs
+++ b/clock-tui/src/bin/main.rs
@@ -5,7 +5,6 @@ use std::time::Duration;
 use clap::Parser;
 use clock_tui::app::App;
 use clock_tui::app::Mode;
-use clock_tui::config::Config;
 use crossterm::event::{self, Event, KeyCode};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};

--- a/clock-tui/src/bin/main.rs
+++ b/clock-tui/src/bin/main.rs
@@ -1,5 +1,5 @@
 use std::error::Error;
-use std::io;
+use std::io::{self, Write};
 use std::time::Duration;
 
 use clap::Parser;
@@ -14,15 +14,16 @@ use ratatui::backend::CrosstermBackend;
 use ratatui::Terminal;
 
 fn main() -> Result<(), Box<dyn Error>> {
+    // Parse command line arguments
+    // Must be done first so `--help` isn't printed to the alternate screen.
+    let mut app = App::parse();
+
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     stdout.execute(EnterAlternateScreen)?;
     let backend = CrosstermBackend::new(&mut stdout);
     let mut terminal = Terminal::new(backend)?;
-
-    // Parse command line arguments
-    let mut app = App::parse();
 
     // Load config and initialize app
     app.init_app();
@@ -62,6 +63,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     drop(terminal);
     disable_raw_mode()?;
     stdout.execute(LeaveAlternateScreen)?;
+
+    // Perform logic such as printing the stopwatch time.
+    // Must be done after leaving alternate screen.
+    app.on_exit();
+    io::stdout().flush()?;
 
     Ok(())
 }

--- a/clock-tui/src/clock_text/font/bricks.rs
+++ b/clock-tui/src/clock_text/font/bricks.rs
@@ -1,6 +1,5 @@
-use std::cmp::min;
 
-use ratatui::{buffer::Buffer, layout::Rect, style::Style};
+use ratatui::{buffer::Buffer, style::Style};
 
 use crate::clock_text::point::Point;
 
@@ -106,7 +105,7 @@ impl BricksFont {
 }
 
 impl Font for BricksFont {
-    fn get_char(&self, c: char) -> Option<&[Point]> {
+    fn get_char(&self, _c: char) -> Option<&[Point]> {
         None // We don't use points for BricksFont
     }
 

--- a/clock-tui/src/config.rs
+++ b/clock-tui/src/config.rs
@@ -1,7 +1,5 @@
-use chrono::Duration;
 use chrono_tz::Tz;
 use serde::{Deserialize, Deserializer};
-use std::path::PathBuf;
 
 fn deserialize_timezone<'de, D>(deserializer: D) -> Result<Option<Tz>, D::Error>
 where


### PR DESCRIPTION
1. `--help` was getting printed to the alternate screen due to cli parsing happening after tui initialization
2. the stopwatch time was not getting printed due to `on_exit` not getting called anymore
3. the code now compiles with no warnings thanks to `cargo fix`