### PR TITLE
Add app.is_ended() check back to the main event loop

### DIFF
--- a/clock-tui/src/bin/main.rs
+++ b/clock-tui/src/bin/main.rs
@@ -28,6 +28,9 @@ fn main() -> Result<(), Box<dyn Error>> {
     app.init_app();
 
     loop {
+        if app.is_ended() {
+            break;
+        }
         terminal.draw(|f| app.ui(f))?;
 
         if event::poll(Duration::from_millis(250))? {


### PR DESCRIPTION
Hi,

I noticed that the `--quit` / `-Q` flag for `timer` subcommand doesn't work. After a quick trace I found `app.is_ended()` never got called.
I think it was not intended therefore raise this PR to fix it.

How to test:

`tclock timer -d 5s -Q`: the program exits after timer ended (5s)
`tclock timer -d 5s -Q -e notify-send hi`: the program exits after timer ended (5s) and `notify-send` was executed successfully



---

It was removed while migrating to ratatui: 9e4926dba5bb7a8981f44543c699ec419396d204

* Fix timer -Q flag doesn't work