### PR TITLE
Added ability to format the date on the clock

### DIFF
--- a/clock-tui/src/app.rs
+++ b/clock-tui/src/app.rs
@@ -32,7 +32,7 @@ pub enum Mode {
         timezone: Option<Tz>,
         /// Custom date format, for example "%a, %d %b %Y", defaults to "%Y-%m-%d"
         #[clap(short = 'f', long)]
-        format_date: String,
+        format_date: Option<String>,
         /// Do not show date
         #[clap(short = 'D', long, action)]
         no_date: bool,
@@ -182,7 +182,7 @@ impl App {
                         millis: clock_config.map(|c| c.show_millis).unwrap_or(false),
                         no_seconds: !clock_config.map(|c| c.show_seconds).unwrap_or(true),
                         timezone: clock_config.and_then(|c| c.timezone),
-                        format_date: clock_config.map(|c| c.format_date.clone()).unwrap_or("%Y-%m-%d".to_string()),
+                        format_date: clock_config.and_then(|c| c.format_date.clone()),
                     }
                 }
             });
@@ -207,7 +207,7 @@ impl App {
             millis: false,
             no_seconds: false,
             timezone: None,
-            format_date: "%Y-%m-%d".to_string(),
+            format_date: Some("%Y-%m-%d".to_string()),
         }) {
             Mode::Clock {
                 no_date,
@@ -224,7 +224,7 @@ impl App {
                     show_millis: *millis || clock_config.map(|c| c.show_millis).unwrap_or(false),
                     show_secs: !no_seconds && clock_config.map(|c| c.show_seconds).unwrap_or(true),
                     timezone: timezone.or_else(|| clock_config.and_then(|c| c.timezone)),
-                    format_date: format_date.clone(),
+                    format_date: format_date.clone().or_else(|| clock_config.and_then(|c| c.format_date.clone())),
                 });
             }
             Mode::Timer {

--- a/clock-tui/src/app.rs
+++ b/clock-tui/src/app.rs
@@ -30,6 +30,9 @@ pub enum Mode {
         /// Custome timezone, for example "America/New_York", use local timezone if not specificed
         #[clap(short = 'z', long, value_parser=parse_timezone)]
         timezone: Option<Tz>,
+        /// Custom date format, for example "%a, %d %b %Y", defaults to "%Y-%m-%d"
+        #[clap(short = 'f', long)]
+        format_date: String,
         /// Do not show date
         #[clap(short = 'D', long, action)]
         no_date: bool,
@@ -179,6 +182,7 @@ impl App {
                         millis: clock_config.map(|c| c.show_millis).unwrap_or(false),
                         no_seconds: !clock_config.map(|c| c.show_seconds).unwrap_or(true),
                         timezone: clock_config.and_then(|c| c.timezone),
+                        format_date: clock_config.map(|c| c.format_date.clone()).unwrap_or("%Y-%m-%d".to_string()),
                     }
                 }
             });
@@ -203,12 +207,14 @@ impl App {
             millis: false,
             no_seconds: false,
             timezone: None,
+            format_date: "%Y-%m-%d".to_string(),
         }) {
             Mode::Clock {
                 no_date,
                 no_seconds,
                 millis,
                 timezone,
+                format_date,
             } => {
                 let clock_config = config.as_ref().map(|c| &c.clock);
                 self.clock = Some(Clock {
@@ -218,6 +224,7 @@ impl App {
                     show_millis: *millis || clock_config.map(|c| c.show_millis).unwrap_or(false),
                     show_secs: !no_seconds && clock_config.map(|c| c.show_seconds).unwrap_or(true),
                     timezone: timezone.or_else(|| clock_config.and_then(|c| c.timezone)),
+                    format_date: format_date.clone(),
                 });
             }
             Mode::Timer {

--- a/clock-tui/src/app/modes/clock.rs
+++ b/clock-tui/src/app/modes/clock.rs
@@ -13,6 +13,7 @@ pub(crate) struct Clock {
     pub show_millis: bool,
     pub show_secs: bool,
     pub timezone: Option<Tz>,
+    pub format_date: String,
 }
 
 impl Widget for &Clock {
@@ -34,7 +35,10 @@ impl Widget for &Clock {
         let font = BricksFont::new(self.size);
         let text = ClockText::new(time_str.to_string(), &font, self.style);
         let header = if self.show_date {
-            let mut title = now.format("%Y-%m-%d").to_string();
+            let mut title = now.format(&self.format_date).to_string();
+            if title == self.format_date {
+                title = now.format("%Y-%m-%d").to_string();
+            }
             if let Some(tz) = self.timezone {
                 title.push(' ');
                 title.push_str(tz.name());

--- a/clock-tui/src/app/modes/clock.rs
+++ b/clock-tui/src/app/modes/clock.rs
@@ -1,6 +1,6 @@
 use crate::clock_text::font::bricks::BricksFont;
 use crate::clock_text::ClockText;
-use chrono::{Local, Utc};
+use chrono::{Local, Utc, format::{Item, StrftimeItems}};
 use chrono_tz::Tz;
 use ratatui::{buffer::Buffer, layout::Rect, style::Style, widgets::Widget};
 
@@ -13,7 +13,7 @@ pub(crate) struct Clock {
     pub show_millis: bool,
     pub show_secs: bool,
     pub timezone: Option<Tz>,
-    pub format_date: String,
+    pub format_date: Option<String>,
 }
 
 impl Widget for &Clock {
@@ -35,8 +35,10 @@ impl Widget for &Clock {
         let font = BricksFont::new(self.size);
         let text = ClockText::new(time_str.to_string(), &font, self.style);
         let header = if self.show_date {
-            let mut title = now.format(&self.format_date).to_string();
-            if title == self.format_date {
+            let mut title;
+            if self.format_date.is_some() && !StrftimeItems::new(&self.format_date.as_ref().unwrap()).any(|i| matches!(i, Item::Error)) {
+                title = now.format(&self.format_date.as_ref().unwrap()).to_string();
+            } else {
                 title = now.format("%Y-%m-%d").to_string();
             }
             if let Some(tz) = self.timezone {

--- a/clock-tui/src/bin/main.rs
+++ b/clock-tui/src/bin/main.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         no_date: false,
                         no_seconds: false,
                         millis: false,
-                        format_date: "%Y-%m-%d".to_string(),
+                        format_date: None,
                     }),
                     KeyCode::Char('w') => app.set_mode(Mode::Stopwatch),
                     KeyCode::Char('t') => app.set_mode(Mode::Timer {

--- a/clock-tui/src/bin/main.rs
+++ b/clock-tui/src/bin/main.rs
@@ -43,6 +43,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         no_date: false,
                         no_seconds: false,
                         millis: false,
+                        format_date: "%Y-%m-%d".to_string(),
                     }),
                     KeyCode::Char('w') => app.set_mode(Mode::Stopwatch),
                     KeyCode::Char('t') => app.set_mode(Mode::Timer {

--- a/clock-tui/src/config.rs
+++ b/clock-tui/src/config.rs
@@ -46,6 +46,8 @@ pub struct ClockConfig {
     pub show_millis: bool,
     #[serde(default, deserialize_with = "deserialize_timezone")]
     pub timezone: Option<Tz>,
+    #[serde(default = "default_date_format")]
+    pub format_date: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -100,6 +102,7 @@ impl Default for ClockConfig {
             show_seconds: default_true(),
             show_millis: default_false(),
             timezone: None,
+            format_date: default_date_format(),
         }
     }
 }
@@ -158,6 +161,10 @@ fn default_false() -> bool {
 
 fn default_timer_durations() -> Vec<String> {
     vec!["25m".to_string(), "5m".to_string()]
+}
+
+fn default_date_format() -> String {
+    "%Y-%m-%d".to_string()
 }
 
 impl Config {

--- a/clock-tui/src/config.rs
+++ b/clock-tui/src/config.rs
@@ -46,8 +46,8 @@ pub struct ClockConfig {
     pub show_millis: bool,
     #[serde(default, deserialize_with = "deserialize_timezone")]
     pub timezone: Option<Tz>,
-    #[serde(default = "default_date_format")]
-    pub format_date: String,
+    #[serde(default)]
+    pub format_date: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -102,7 +102,7 @@ impl Default for ClockConfig {
             show_seconds: default_true(),
             show_millis: default_false(),
             timezone: None,
-            format_date: default_date_format(),
+            format_date: None,
         }
     }
 }
@@ -161,10 +161,6 @@ fn default_false() -> bool {
 
 fn default_timer_durations() -> Vec<String> {
     vec!["25m".to_string(), "5m".to_string()]
-}
-
-fn default_date_format() -> String {
-    "%Y-%m-%d".to_string()
 }
 
 impl Config {


### PR DESCRIPTION
This is something I required for my own personal use as I didn't like the formatting of the date, figured I would add the ability to customize as well. 

Appears to work well - if a nonsense string with no valid formatting is used then it reverts to the default. 